### PR TITLE
fix(drift): kube context, kubeconfig and auth

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var envSettings *EnvSettings
+
 func getRootCommand() *cobra.Command {
 	rootCommand := &cobra.Command{
 		Use:   "drift [command]",
@@ -24,6 +26,7 @@ func getRootCommand() *cobra.Command {
 		},
 	}
 	rootCommand.SetUsageTemplate(getUsageTemplate())
+	envSettings = envSettings.New()
 
 	return rootCommand
 }
@@ -49,6 +52,10 @@ func getRunCommand() *cobra.Command {
 			drifts.SetLogger(drifts.LogLevel)
 			drifts.SetWriter(os.Stdout)
 			cmd.SilenceUsage = true
+
+			drifts.SetKubeConfig(envSettings.KubeConfig)
+			drifts.SetKubeContext(envSettings.KubeContext)
+			drifts.SetNamespace(envSettings.Namespace)
 
 			drifts.SetRelease(args[0])
 			if !drifts.FromRelease {
@@ -87,6 +94,10 @@ Do note that this is expensive operation since multiple kubectl command would be
 			drifts.SetLogger(drifts.LogLevel)
 			drifts.SetWriter(os.Stdout)
 			cmd.SilenceUsage = true
+
+			drifts.SetKubeConfig(envSettings.KubeConfig)
+			drifts.SetKubeContext(envSettings.KubeContext)
+			drifts.SetNamespace(envSettings.Namespace)
 
 			if !drifts.SkipValidation {
 				if !drifts.ValidatePrerequisite() {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+type EnvSettings struct {
+	KubeConfig  string
+	KubeContext string
+	Namespace   string
+}
+
+func (s *EnvSettings) New() *EnvSettings {
+	envSettings := EnvSettings{
+		Namespace:   os.Getenv("HELM_NAMESPACE"),
+		KubeContext: os.Getenv("HELM_KUBECONTEXT"),
+		KubeConfig:  os.Getenv("KUBECONFIG"),
+	}
+	return &envSettings
+}
+
+func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
 	github.com/thoas/go-funk v0.9.3
 	gopkg.in/yaml.v3 v3.0.1
@@ -99,7 +100,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/pkg/command/exec.go
+++ b/pkg/command/exec.go
@@ -9,15 +9,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	HelmContext   = "HELM_KUBECONTEXT"
-	HelmNamespace = "HELM_NAMESPACE"
-	KubeConfig    = "KUBECONFIG"
-)
-
 // Exec implements methods that set's and run's the kubectl command.
 type Exec interface {
-	SetKubeCmd(namespace string, args ...string)
+	SetKubeCmd(kubeConfig string, kubeContext string, namespace string, args ...string)
 	RunKubeCmd(deviation deviation.Deviation) (deviation.Deviation, error)
 }
 

--- a/pkg/diff.go
+++ b/pkg/diff.go
@@ -41,7 +41,7 @@ func (drift *Drift) Diff(renderedManifests deviation.DriftedRelease) (deviation.
 			nameSpace := drift.setNameSpace(renderedManifests, dvn)
 			drift.log.Debugf("setting namespace to %s", nameSpace)
 
-			cmd.SetKubeCmd(nameSpace, arguments...)
+			cmd.SetKubeCmd(drift.kubeConfig, drift.kubeContext, nameSpace, arguments...)
 
 			dft, err := cmd.RunKubeCmd(dvn)
 			if err != nil {

--- a/pkg/drift_all.go
+++ b/pkg/drift_all.go
@@ -20,8 +20,6 @@ func (drift *Drift) GetAllDrift() {
 
 	drift.log.Debugf("got all required values to identify drifts from chart/release '%s' proceeding furter to fetch the same", drift.release)
 
-	drift.setReleaseNameSpace()
-
 	if err := drift.setExternalDiff(); err != nil {
 		drift.log.Fatalf("%v", err)
 	}

--- a/pkg/from_release.go
+++ b/pkg/from_release.go
@@ -7,6 +7,8 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
+	// Import to initialize client auth plugins.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 // getChartFromRelease should get the manifest from the selected release.
@@ -16,6 +18,17 @@ func (drift *Drift) getChartFromRelease() ([]byte, error) {
 	drift.log.Debugf("fetching chart manifest for release '%s' from kube cluster", drift.release)
 
 	actionConfig := new(action.Configuration)
+
+	kubeContext := drift.kubeContext
+	if len(kubeContext) != 0 {
+		settings.KubeContext = kubeContext
+	}
+
+	kubeConfig := drift.kubeConfig
+	if len(kubeConfig) != 0 {
+		settings.KubeConfig = kubeConfig
+	}
+
 	if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), log.Printf); err != nil {
 		drift.log.Error("oops initialising helm client errored with", err)
 


### PR DESCRIPTION
Fixes these issues:
- Auth issues when connecting with specific provider (gcp, oidc..) through the use of kube context, kubeconfig and namespace
```
$ HELM_KUBECONTEXT="kind-kind" HELM_NAMESPACE="default" ./helm-drift_v0.1.0 run my-release --from-release
{"level":"error","msg":"fetching helm release 'my-release' errored with 'Kubernetes cluster unreachable: no Auth Provider found for name \"oidc\"'","time":"2023-09-26T16:08:14+02:00"}
{"level":"fatal","msg":"Kubernetes cluster unreachable: no Auth Provider found for name \"oidc\"","time":"2023-09-26T16:08:14+02:00"}
```
- Release namespace:
```
$ ./helm-drift_v0.1.0 run my-release --from-release
{"level":"fatal","msg":"calculating diff errored with: running kubectl diff errored with exit code: exit status 2 ,with message: Error from server (NotFound): namespaces \"=\" not found\n\nrunning kubectl diff errored with exit code: exit status 2 ,with message: Error from server (NotFound): namespaces \"=\" not found\n\nrunning kubectl diff errored with exit code: exit status 2 ,with message: Error from server (NotFound): namespaces \"=\" not found\n","time":"2023-09-26T12:53:17+02:00"}
```