### PR TITLE
Use the same yaml library that helm itself uses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	github.com/thoas/go-funk v0.9.3
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.2
 	k8s.io/client-go v0.29.0
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -132,6 +132,7 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.29.0 // indirect
 	k8s.io/apiextensions-apiserver v0.29.0 // indirect
 	k8s.io/apimachinery v0.29.0 // indirect
@@ -147,5 +148,4 @@ require (
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/nikhilsbhat/helm-drift/pkg/errors"
 	"github.com/thoas/go-funk"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 type (

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -24,6 +24,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: sample
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/managed-by: helm
     app.kubernetes.io/name: sample
     app.kubernetes.io/version: 1.16.0
     helm.sh/chart: sample-0.1.0

--- a/pkg/render.go
+++ b/pkg/render.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/nikhilsbhat/helm-drift/pkg/deviation"
 	"github.com/olekukonko/tablewriter"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 func (drift *Drift) render(drifts []deviation.DriftedRelease) error {


### PR DESCRIPTION
Helm appears to use a very specific opinionated library for yaml which among other differences allows for things like duplicate keys which are not actually valid yaml

This is because under the hood its basically using json which is more permissive then converting that to yaml

Source
https://github.com/helm/helm/blob/c6beb169d26751efd8131a5d65abe75c81a334fb/pkg/chartutil/values.go#L26C1-L26C20

Fixes https://github.com/nikhilsbhat/helm-drift/issues/22

I tested this by adding a duplicate line in the test under k8s which is essentially the duplicate in our helm config that triggers this

I also then tested the locally built binary 

```
make build.local
./helm-drift_v0.1.0 all 
```