### PR TITLE
Add support for dyff when using --ignore-hpa-changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nikhilsbhat/helm-drift
 go 1.22.5
 
 require (
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/goccy/go-yaml v1.11.3
 	github.com/nikhilsbhat/common v0.0.6-0.20240705174411-75b5dafa56bb
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.7 h1:vl/nj3Bar/CvJSYo7gIQPyRWc9f3c6IeSNavBTSZNZQ=
 github.com/Microsoft/hcsshim v0.11.7/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
 github.com/alecthomas/assert/v2 v2.7.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.14.0 h1:R3+wzpnUArGcQz7fCETQBzO5n9IMNi13iIs46aU4V9E=

--- a/pkg/diff.go
+++ b/pkg/diff.go
@@ -84,10 +84,10 @@ func (drift *Drift) Diff(renderedManifests *deviation.DriftedRelease) (*deviatio
 				return
 			}
 
-			wasHpaScaled, err := drift.WasScaledByHpa(dft.Deviations)
+			hasOnlyChangesScaledByHpa, err := drift.HasOnlyChangesScaledByHpa(dft.Deviations)
 			handleError(err)
 
-			if dft.HasDrift && (!wasHpaScaled || !drift.IgnoreHPAChanges) {
+			if dft.HasDrift && (!hasOnlyChangesScaledByHpa || !drift.IgnoreHPAChanges) {
 				renderedManifests.HasDrift = true
 			} else {
 				dft.HasDrift = false

--- a/pkg/hpa.go
+++ b/pkg/hpa.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/nikhilsbhat/helm-drift/pkg/errors"
@@ -54,20 +55,82 @@ func buildConfigWithContextFromFlags(context string, kubeConfigPath string) (*re
 		}).ClientConfig()
 }
 
-func (drift *Drift) WasScaledByHpa(diffOutput string) (bool, error) {
-	stringReader := strings.NewReader(diffOutput)
+func (drift *Drift) HasOnlyChangesScaledByHpa(diffOutput string) (bool, error) {
+	customDiff := ""
+	if drift.CustomDiff != "" {
+		customDiff = drift.CustomDiff
+	} else if os.Getenv("KUBECTL_EXTERNAL_DIFF") != "" {
+		customDiff = os.Getenv("KUBECTL_EXTERNAL_DIFF")
+	}
 
+	diffToolUsed := ""
+	if customDiff != "" {
+		diffToolUsed = strings.Split(customDiff, " ")[0]
+	} else {
+		diffToolUsed = "diff"
+	}
+
+	drift.log.Infof("custom diff: %s", diffToolUsed)
+
+	if diffToolUsed != "diff" && diffToolUsed != "dyff" {
+		drift.log.Warnf("--ignore-hpa-changes currently only supports diff and dyff, not '%s'", diffToolUsed)
+		return false, nil
+	}
+
+	hasOnlyChangesScaledByHpa := true
+
+	stringReader := strings.NewReader(diffOutput)
 	scanner := bufio.NewScanner(stringReader)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.Contains(line, "+  replicas:") {
-			return true, nil
+
+		if diffToolUsed == "diff" && !diffLineHasChangesNonHpaRelated(line) {
+			continue
+		} else if diffToolUsed == "dyff" && !dyffLineHasChangesNonHpaRelated(line) {
+			continue
 		}
+
+		hasOnlyChangesScaledByHpa = false
+		break
 	}
 
 	if err := scanner.Err(); err != nil {
 		return false, err
 	}
 
-	return false, nil
+	return hasOnlyChangesScaledByHpa, nil
+}
+
+func diffLineHasChangesNonHpaRelated(line string) bool {
+	// skip diff output lines starting with +++ or ---
+	if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+		return false
+	}
+
+	// skip lines that have no changes
+	if !strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "-") {
+		return false
+	}
+
+	// check if the line changed is related to replicas or generation, then continue, since we are looking for other fields changed besides replicas and generation
+	if strings.Contains(line, "+  replicas:") || strings.Contains(line, "-  replicas:") ||
+		strings.Contains(line, "+  generation:") || strings.Contains(line, "-  generation:") {
+		return false
+	}
+
+	return true
+}
+
+func dyffLineHasChangesNonHpaRelated(line string) bool {
+	// skip empty lines and lines starting with space
+	if line == "" || strings.HasPrefix(line, " ") {
+		return false
+	}
+
+	// check if the line changed is related to replicas or generation, then continue, since we are looking for other fields changed besides replicas and generation
+	if strings.Contains(line, "spec.replicas") || strings.Contains(line, "metadata.generation") {
+		return false
+	}
+
+	return true
 }

--- a/pkg/hpa.go
+++ b/pkg/hpa.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/acarl005/stripansi"
 	"github.com/nikhilsbhat/helm-drift/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -78,6 +79,8 @@ func (drift *Drift) HasOnlyChangesScaledByHpa(diffOutput string) (bool, error) {
 	}
 
 	hasOnlyChangesScaledByHpa := true
+
+	diffOutput = stripansi.Strip(diffOutput)
 
 	stringReader := strings.NewReader(diffOutput)
 	scanner := bufio.NewScanner(stringReader)


### PR DESCRIPTION
When `--ignore-hpa-changes` is used with `--custom-diff “dyff ...”`, it cannot recognize hpa changes. Also, `--ignore-hpa-changes` ignored all other drifts when `replicas` was changed.

I fixed this by adding support specifically for dyff and checking that only `spec.replicas` and/or `metadata.generation` are changed and nothing else. Also I strip ansi from diff output, so we can have colored output.

Command used for testing:
`helm drift run <release> --from-release --custom-diff "dyff between --color on --omit-header --set-exit-code"`

Fixes #35
